### PR TITLE
Support for ssh1106 display

### DIFF
--- a/EnvironmentMonitorArduino.ino
+++ b/EnvironmentMonitorArduino.ino
@@ -36,9 +36,6 @@
 // Display
 #include <Wire.h>
 #include <Adafruit_GFX.h>
-// #include <Fonts/FreeMono12pt7b.h>
-// 
-// #include <SH1106.h>
 
 #define SCREEN_WIDTH 128 // OLED display width, in pixels
 #define SCREEN_HEIGHT 64 // 32 // OLED display height, in pixels


### PR DESCRIPTION
- Support for ssh1106 added using the Adafruit library
- Whether to use SSH1106 or SSD1306 must be done using #define blocks