### PR TITLE
Increased max output delay, changes for displaying the delay in display

### DIFF
--- a/EnvironmentMonitorArduino.ino
+++ b/EnvironmentMonitorArduino.ino
@@ -513,11 +513,11 @@ int calculateMeasurements()
     int rowCount = sensors.size();
     #ifdef MOTIONSENSOR_IN_PINS
       #ifdef MOTIONSENSOR_DISPLAY_ON_DELAY
-        unsigned long delayInMs = motionSensor->getOutputDelayLeft();
-        if (delayInMs > 0) 
+        float delayInS = motionSensor->getOutputDelayLeft();
+        if (delayInS > 0) 
         {
-          display.println("ON DELAY (ms): ");
-          display.println(String(delayInMs)); 
+          display.println("ON DELAY (s): ");
+          display.println(String(delayInS)); 
           rowCount+=2;
         }
       #endif

--- a/EnvironmentMonitorArduino.ino
+++ b/EnvironmentMonitorArduino.ino
@@ -40,8 +40,6 @@
 #include <Adafruit_GFX.h>
 
 #define SCREEN_WIDTH 128 // OLED display width, in pixels
- // 32 // OLED display height, in pixels
-
 #define USE_DISPLAY 1 // Uncomment in order not to use display
 #define SH1106 1 // Uncomment to use SSD1306
 // #define SSD1306
@@ -516,9 +514,8 @@ int calculateMeasurements()
         float delayInS = motionSensor->getOutputDelayLeft();
         if (delayInS > 0) 
         {
-          display.println("ON DELAY (s): ");
-          display.println(String(delayInS)); 
-          rowCount+=2;
+          display.println("ON DELAY (s): " + String(delayInS));
+          rowCount++;
         }
       #endif
     #endif   

--- a/MotionSensor.cpp
+++ b/MotionSensor.cpp
@@ -92,13 +92,13 @@ void MotionSensor::checkOutputs()
   }
 }
 
-unsigned long MotionSensor::getOutputDelayLeft()
+float MotionSensor::getOutputDelayLeft()
 {
   if (lastMotionOnMillis != 0) 
   {
     unsigned long millisNow = millis();
     unsigned long diff = millisNow - lastMotionOnMillis;
-    return motionControlDelaysMs - diff;
+    return (motionControlDelaysMs - diff) / (float)1000.0;
   } else 
   {
     return 0;
@@ -128,9 +128,9 @@ void MotionSensor::setMotionControlDelay(unsigned long delayInMs)
   if (delayInMs < 10000) 
   {
     valueToSet = 10000;
-  } else if (delayInMs > 600000) 
+  } else if (delayInMs > OUTPUT_MAX_DELAY_MS) 
   {
-    valueToSet = 600000;
+    valueToSet = OUTPUT_MAX_DELAY_MS;
   } 
 
   debugPrint("Setting motion control delay to: " + String(valueToSet));

--- a/MotionSensor.cpp
+++ b/MotionSensor.cpp
@@ -123,11 +123,11 @@ void MotionSensor::setMotionControlStatus(MotionControlStatus status)
 // Set delay in ms
 void MotionSensor::setMotionControlDelay(unsigned long delayInMs)
 {
-  debugPrint("Setting motion control delay");
+  debugPrint("Setting motion control delay. Given value: " + String(delayInMs));
   unsigned long valueToSet = delayInMs;
-  if (delayInMs < 10000) 
+  if (delayInMs < OUTPUT_MIN_DELAY_MS) 
   {
-    valueToSet = 10000;
+    valueToSet = OUTPUT_MIN_DELAY_MS;
   } else if (delayInMs > OUTPUT_MAX_DELAY_MS) 
   {
     valueToSet = OUTPUT_MAX_DELAY_MS;

--- a/MotionSensor.h
+++ b/MotionSensor.h
@@ -5,6 +5,8 @@
 #include <Arduino.h>
 #include <initializer_list>
 
+#define OUTPUT_MAX_DELAY_MS 1200000
+
 enum MotionControlStatus {
     AlwaysOff = 0,
     AlwaysOn = 1,
@@ -34,7 +36,7 @@ public:
     int readMotion(bool aggregate) override;
     void resetAverages() override;
 
-    unsigned long getOutputDelayLeft();
+    float getOutputDelayLeft();
 
     void checkOutputs(); 
     void setMotionControlStatus(MotionControlStatus status);

--- a/MotionSensor.h
+++ b/MotionSensor.h
@@ -6,6 +6,7 @@
 #include <initializer_list>
 
 #define OUTPUT_MAX_DELAY_MS 1200000
+#define OUTPUT_MIN_DELAY_MS 10000
 
 enum MotionControlStatus {
     AlwaysOff = 0,


### PR DESCRIPTION
- Allow maximum of 20 mins output delay when outputs are controlled with motion control. This is defined with a macro.
- Show seconds instead of milliseconds in the display when showing output delay.