### PR TITLE
Fill additional info when sending messages to IoT hub

### DIFF
--- a/EnvironmentMonitorArduino.ino
+++ b/EnvironmentMonitorArduino.ino
@@ -89,7 +89,7 @@
 #define CONFIG_FREERTOS_NUMBER_OF_CORES 1 
 
 #include "esp_task_wdt.h"
-
+#include "esp_system.h"
 // C99 libraries
 #include <cstdlib>
 #include <string.h>
@@ -568,9 +568,17 @@ static int generateTelemetryPayload()
 {
   Logger.Info("--Generating IOT hub message--");
   Logger.Info("MeasureCount: " + String(measureCount));
+  unsigned long millisNow = millis();
+  uint32_t randomNumber = esp_random();
   JsonDocument doc;
+  String identifier = String(randomNumber) + "_" + String(IOT_CONFIG_DEVICE_ID) + "_" + String(millisNow) + "_" + String(loopCount) + "_" + String(sentMessageCount);
+  Logger.Info("Message identifier: " + identifier);
   doc["deviceId"] = IOT_CONFIG_DEVICE_ID;
   doc["firstMessage"] = !hasSentMessage; 
+  doc["identifier"] = identifier;
+  doc["messageCount"] = sentMessageCount;
+  doc["loopCount"] = loopCount;
+  doc["uptime"] = millisNow;
   int jsonMeasureCount = 0;
   for (Sensor* sensor : sensors) 
   {

--- a/EnvironmentMonitorArduino.ino
+++ b/EnvironmentMonitorArduino.ino
@@ -217,10 +217,10 @@ static String generateIdentifier(unsigned long uptime, unsigned long messageOrde
 {
   char buffer[9];
   String result;
-  // Uptime / millis
+  // Message order / count of sent messages
   sprintf(buffer, "%08X", messageOrder);
   result = String(buffer);
-  // Message order sent message count, starts from 0
+  // Uptime / millis
   sprintf(buffer, "%08X", uptime);
   result += String(buffer);
   for (uint8_t i = 0; i < numOfRandParts; i++) 

--- a/EnvironmentMonitorArduino.ino
+++ b/EnvironmentMonitorArduino.ino
@@ -571,7 +571,7 @@ static int generateTelemetryPayload()
   unsigned long millisNow = millis();
   uint32_t randomNumber = esp_random();
   JsonDocument doc;
-  String identifier = String(randomNumber) + "_" + String(IOT_CONFIG_DEVICE_ID) + "_" + String(millisNow) + "_" + String(loopCount) + "_" + String(sentMessageCount);
+  String identifier = String(randomNumber) + "-" + String(IOT_CONFIG_DEVICE_ID) + "-" + String(millisNow) + "-" + String(loopCount) + "-" + String(sentMessageCount);
   Logger.Info("Message identifier: " + identifier);
   doc["deviceId"] = IOT_CONFIG_DEVICE_ID;
   doc["firstMessage"] = !hasSentMessage; 

--- a/EnvironmentMonitorArduino.ino
+++ b/EnvironmentMonitorArduino.ino
@@ -213,6 +213,25 @@ static void initializeTime() {
   Logger.Info("Time initialized!");
 }
 
+static String generateIdentifier(unsigned long uptime, unsigned long messageOrder, uint8_t numOfRandParts=2)
+{
+  char buffer[9];
+  String result;
+  // Uptime / millis
+  sprintf(buffer, "%08X", messageOrder);
+  result = String(buffer);
+  // Message order sent message count, starts from 0
+  sprintf(buffer, "%08X", uptime);
+  result += String(buffer);
+  for (uint8_t i = 0; i < numOfRandParts; i++) 
+  {
+    sprintf(buffer, "%08X", esp_random());
+    result += String(buffer);
+  }
+
+  return result;
+}
+
 void receivedCallback(char* topic, byte* payload, unsigned int length) {
   Logger.Info("Received [");
   Logger.Info(topic);
@@ -571,7 +590,7 @@ static int generateTelemetryPayload()
   unsigned long millisNow = millis();
   uint32_t randomNumber = esp_random();
   JsonDocument doc;
-  String identifier = String(randomNumber) + "-" + String(IOT_CONFIG_DEVICE_ID) + "-" + String(millisNow) + "-" + String(loopCount) + "-" + String(sentMessageCount);
+  String identifier = generateIdentifier(millisNow, sentMessageCount);
   Logger.Info("Message identifier: " + identifier);
   doc["deviceId"] = IOT_CONFIG_DEVICE_ID;
   doc["firstMessage"] = !hasSentMessage; 


### PR DESCRIPTION
When sending messages to IoT hub, include the following information:

- Loop count
- Uptime / ``millis()``
- Number of sent messages (before the one being sent)
- Identifier. Semi unique identifier for a message. Achieved by converting the following numbers into HEX format (length 8) and forming a string of them:
  - Message sequence
  - Uptime (``millis()``)
  - x calls to ``esp_random()``